### PR TITLE
Step input cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ steps:
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
 | `archive_path` | Path to the iOS or tvOS archive (.xcarchive) which should be exported. | required | `$BITRISE_XCARCHIVE_PATH` |
-| `export_method` | `auto-detect` option is **DEPRECATED** - use direct export methods!  Describes how Xcode should export the archive.     If you select `auto-detect`, the step will figure out the proper export method   based on the provisioning profile embedded into the generated xcode archive. | required | `auto-detect` |
-| `upload_bitcode` | For __App Store__ exports, should the package include bitcode? | required | `yes` |
+| `product` | Describes which product to export. Possible options are App or App Clip. | required | `app` |
+| `distribution_method` | Describes how Xcode should export the archive. | required |  |
+| `export_development_team` | The Developer Portal team to use for this export.  Format example: `1MZX23ABCD4` |  |  |
 | `compile_bitcode` | For __non-App Store__ exports, should Xcode re-compile the app from bitcode? | required | `yes` |
-| `team_id` | The Developer Portal team to use for this export.  Format example:  - `1MZX23ABCD4` |  |  |
-| `product` | Describes which product to export.    Possible options are App or App Clip. | required | `app` |
-| `custom_export_options_plist_content` | Specifies a custom export options plist content that configures archive exporting. If empty, step generates these options based on the embedded provisioning profile, with default values.  Auto generated export options available for export methods:  - app-store - ad-hoc - enterprise - development  If step doesn't find export method based on provisioning profile, development will be use.  Call `xcodebuild -help` for available export options. |  |  |
+| `upload_bitcode` | For __App Store__ exports, should the package include bitcode? | required | `yes` |
+| `custom_export_options_plist_content` | Specifies a custom export options plist content that configures archive exporting. If empty, step generates these options based on the embedded provisioning profile, with default values.  Call `xcodebuild -help` for available export options. |  |  |
 | `verbose_log` | Enable verbose logging? | required | `yes` |
 </details>
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -53,23 +53,23 @@ workflows:
     - path::./:
         title: Step Test - iOS archive
         inputs:
-        - export_method: development
+        - distribution_method: development
         - archive_path: ./archives/ios.xcarchive
     - path::./:
         title: Step Test - Custom plist
         inputs:
-        - export_method: development
+        - distribution_method: development
         - archive_path: ./archives/ios.xcarchive
         - custom_export_options_plist_content: $CUSTOM_PLIST
     - path::./:
         title: Step Test - TV OS
         inputs:
-        - export_method: development
+        - distribution_method: development
         - archive_path: ./archives/TVOS.xcarchive
     - path::./:
         title: Step Test - App Clip
         inputs:
-        - export_method: development
+        - distribution_method: development
         - archive_path: ./archives/Fruta.xcarchive
         - product: app-clip
 

--- a/main.go
+++ b/main.go
@@ -48,37 +48,37 @@ func ParseExportProduct(product string) (ExportProduct, error) {
 	case "app-clip":
 		return ExportProductAppClip, nil
 	default:
-		return ExportProduct(""), fmt.Errorf("unkown method (%s)", product)
+		return "", fmt.Errorf("unkown method (%s)", product)
 	}
 }
 
 // Config ...
 type Config struct {
-	ArchivePath                     string `env:"archive_path,dir"`
-	DistributionMethod              string `env:"distribution_method,opt[development,app-store,ad-hoc,enterprise]"`
-	UploadBitcode                   bool   `env:"upload_bitcode,opt[yes,no]"`
-	CompileBitcode                  bool   `env:"compile_bitcode,opt[yes,no]"`
-	TeamID                          string `env:"team_id"`
-	ProductToDistribute             string `env:"product,opt[app,app-clip]"`
-	CustomExportOptionsPlistContent string `env:"custom_export_options_plist_content"`
+	ArchivePath               string `env:"archive_path,dir"`
+	DistributionMethod        string `env:"distribution_method,opt[development,app-store,ad-hoc,enterprise]"`
+	UploadBitcode             bool   `env:"upload_bitcode,opt[yes,no]"`
+	CompileBitcode            bool   `env:"compile_bitcode,opt[yes,no]"`
+	TeamID                    string `env:"export_development_team"`
+	ProductToDistribute       string `env:"product,opt[app,app-clip]"`
+	ExportOptionsPlistContent string `env:"export_options_plist_content"`
 
 	DeployDir  string `env:"BITRISE_DEPLOY_DIR"`
 	VerboseLog bool   `env:"verbose_log,opt[yes,no]"`
 }
 
 func (configs *Config) validate() error {
-	// Validate CustomExportOptionsPlistContent
-	trimmedExportOptions := strings.TrimSpace(configs.CustomExportOptionsPlistContent)
-	if configs.CustomExportOptionsPlistContent != trimmedExportOptions {
-		configs.CustomExportOptionsPlistContent = trimmedExportOptions
-		log.Warnf("CustomExportOptionsPlistContent contains leading and trailing white space, removed:")
-		log.Printf(configs.CustomExportOptionsPlistContent)
+	// Validate ExportOptionsPlistContent
+	trimmedExportOptions := strings.TrimSpace(configs.ExportOptionsPlistContent)
+	if configs.ExportOptionsPlistContent != trimmedExportOptions {
+		configs.ExportOptionsPlistContent = trimmedExportOptions
+		log.Warnf("ExportOptionsPlistContent contains leading and trailing white space, removed:")
+		log.Printf(configs.ExportOptionsPlistContent)
 		fmt.Println()
 	}
-	if configs.CustomExportOptionsPlistContent != "" {
+	if configs.ExportOptionsPlistContent != "" {
 		var options map[string]interface{}
-		if _, err := plist.Unmarshal([]byte(configs.CustomExportOptionsPlistContent), &options); err != nil {
-			return fmt.Errorf("issue with input CustomExportOptionsPlistContent: %s", err.Error())
+		if _, err := plist.Unmarshal([]byte(configs.ExportOptionsPlistContent), &options); err != nil {
+			return fmt.Errorf("issue with input ExportOptionsPlistContent: %s", err.Error())
 		}
 	}
 
@@ -433,11 +433,11 @@ func main() {
 
 	log.Infof("Exporting with export options...")
 
-	if configs.CustomExportOptionsPlistContent != "" {
-		log.Printf("Custom export options content provided, using it:")
-		fmt.Println(configs.CustomExportOptionsPlistContent)
+	if configs.ExportOptionsPlistContent != "" {
+		log.Printf("Export options content provided, using it:")
+		fmt.Println(configs.ExportOptionsPlistContent)
 
-		if err := fileutil.WriteStringToFile(exportOptionsPath, configs.CustomExportOptionsPlistContent); err != nil {
+		if err := fileutil.WriteStringToFile(exportOptionsPath, configs.ExportOptionsPlistContent); err != nil {
 			fail("Failed to write export options to file, error: %s", err)
 		}
 	} else {

--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestConfig_validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "CustomExportOptionsPlistContent contains whitespace",
+			name: "ExportOptionsPlistContent contains whitespace",
 			fields: fields{
 				CustomExportOptionsPlistContent: "  ",
 			},
@@ -47,24 +47,24 @@ func TestConfig_validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			configs := &Config{
-				ArchivePath:                     tt.fields.ArchivePath,
-				DistributionMethod:              tt.fields.ExportMethod,
-				UploadBitcode:                   tt.fields.UploadBitcode,
-				CompileBitcode:                  tt.fields.CompileBitcode,
-				TeamID:                          tt.fields.TeamID,
-				CustomExportOptionsPlistContent: tt.fields.CustomExportOptionsPlistContent,
-				DeployDir:                       tt.fields.DeployDir,
-				VerboseLog:                      tt.fields.VerboseLog,
+				ArchivePath:               tt.fields.ArchivePath,
+				DistributionMethod:        tt.fields.ExportMethod,
+				UploadBitcode:             tt.fields.UploadBitcode,
+				CompileBitcode:            tt.fields.CompileBitcode,
+				TeamID:                    tt.fields.TeamID,
+				ExportOptionsPlistContent: tt.fields.CustomExportOptionsPlistContent,
+				DeployDir:                 tt.fields.DeployDir,
+				VerboseLog:                tt.fields.VerboseLog,
 			}
 			wantConfigs := &Config{
-				ArchivePath:                     tt.want.ArchivePath,
-				DistributionMethod:              tt.want.ExportMethod,
-				UploadBitcode:                   tt.want.UploadBitcode,
-				CompileBitcode:                  tt.want.CompileBitcode,
-				TeamID:                          tt.want.TeamID,
-				CustomExportOptionsPlistContent: tt.want.CustomExportOptionsPlistContent,
-				DeployDir:                       tt.want.DeployDir,
-				VerboseLog:                      tt.want.VerboseLog,
+				ArchivePath:               tt.want.ArchivePath,
+				DistributionMethod:        tt.want.ExportMethod,
+				UploadBitcode:             tt.want.UploadBitcode,
+				CompileBitcode:            tt.want.CompileBitcode,
+				TeamID:                    tt.want.TeamID,
+				ExportOptionsPlistContent: tt.want.CustomExportOptionsPlistContent,
+				DeployDir:                 tt.want.DeployDir,
+				VerboseLog:                tt.want.VerboseLog,
 			}
 			if err := configs.validate(); (err != nil) != tt.wantErr {
 				t.Errorf("Config.validate() error = %v, wantErr %v", err, tt.wantErr)

--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ func TestConfig_validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			configs := &Config{
 				ArchivePath:                     tt.fields.ArchivePath,
-				ExportMethod:                    tt.fields.ExportMethod,
+				DistributionMethod:              tt.fields.ExportMethod,
 				UploadBitcode:                   tt.fields.UploadBitcode,
 				CompileBitcode:                  tt.fields.CompileBitcode,
 				TeamID:                          tt.fields.TeamID,
@@ -58,7 +58,7 @@ func TestConfig_validate(t *testing.T) {
 			}
 			wantConfigs := &Config{
 				ArchivePath:                     tt.want.ArchivePath,
-				ExportMethod:                    tt.want.ExportMethod,
+				DistributionMethod:              tt.want.ExportMethod,
 				UploadBitcode:                   tt.want.UploadBitcode,
 				CompileBitcode:                  tt.want.CompileBitcode,
 				TeamID:                          tt.want.TeamID,

--- a/step.yml
+++ b/step.yml
@@ -41,7 +41,7 @@ inputs:
     - "app-clip"
     is_required: true
 
-- distribution_method:
+- distribution_method: "development"
   opts:
     title: Distribution method
     summary: Describes how Xcode should export the archive.
@@ -62,7 +62,7 @@ inputs:
     description: |-
       The Developer Portal team to use for this export.
 
-      Format example: '1MZX23ABCD4'
+      Defaults to the team used to build the archive.
 
 - compile_bitcode: "yes"
   opts:
@@ -90,19 +90,17 @@ inputs:
     title: Export options plist content
     summary: Specifies a plist file content that configures archive exporting.
     description: |-
-      Specifies a custom export options plist content that configures archive exporting.
-      If empty, step generates these options based on the embedded provisioning profile,
-      with default values.
+      Specifies a plist file content that configures archive exporting.
 
-      Call 'xcodebuild -help' for available export options.
+      If not specified, the Step will auto-generate it.
 
 # Debugging
 
-- verbose_log: "yes"
+- verbose_log: "no"
   opts:
     category: Debugging
-    title: Enable verbose logging?
-    description: Enable verbose logging?
+    title: Enable verbose logging
+    summary: If this input is set, the Step will print additional logs for debugging.
     is_required: true
     value_options:
     - "yes"

--- a/step.yml
+++ b/step.yml
@@ -31,6 +31,7 @@ inputs:
 
     The input value sets `xcodebuild`’s `-archivePath` option.
     is_required: true
+
 - product: "app"
   opts:
     title: "Select a product to distribute"
@@ -41,6 +42,7 @@ inputs:
     - "app"
     - "app-clip"
     is_required: true
+
 - distribution_method:
   opts:
     title: "Distribution method"
@@ -53,6 +55,9 @@ inputs:
     - "ad-hoc"
     - "enterprise"
     is_required: true
+
+# IPA export configuration
+
 - export_development_team:
   opts:
     title: "Developer Portal team"
@@ -62,6 +67,7 @@ inputs:
 
       Format example: `1MZX23ABCD4`
     category: "IPA export configuration"
+
 - compile_bitcode: "yes"
   opts:
     title: "Rebuild from bitcode"
@@ -84,6 +90,7 @@ inputs:
     - "no"
     is_required: true
     category: "IPA export configuration"
+
 - custom_export_options_plist_content:
   opts:
     title: "Export options plist content"
@@ -95,6 +102,9 @@ inputs:
 
       Call `xcodebuild -help` for available export options.
     category: "IPA export configuration"
+
+# Debugging
+
 - verbose_log: "yes"
   opts:
     category: "Debugging"
@@ -104,6 +114,7 @@ inputs:
     value_options:
     - "yes"
     - "no"
+
 outputs:
 - BITRISE_IPA_PATH:
   opts:

--- a/step.yml
+++ b/step.yml
@@ -24,10 +24,12 @@ toolkit:
 inputs:
 - archive_path: $BITRISE_XCARCHIVE_PATH
   opts:
-    title: iOS or tvOS archive path
-    summary: iOS or tvOS archive path
+    title: Archive path
+    summary: Specifies the archive that should be exported.
     description: |-
-      Path to the iOS or tvOS archive (.xcarchive) which should be exported.
+      Specifies the archive that should be exported.
+
+    The input value sets `xcodebuild`’s `-archivePath` option.
     is_required: true
 - product: "app"
   opts:
@@ -35,7 +37,6 @@ inputs:
     summary: ""
     description: |-
       Describes which product to export.
-      Possible options are App or App Clip.
     value_options:
     - "app"
     - "app-clip"
@@ -64,7 +65,7 @@ inputs:
 - compile_bitcode: "yes"
   opts:
     title: "Rebuild from bitcode"
-    summary: ""
+    summary: "For __non-App Store__ exports, should Xcode re-compile the app from bitcode?"
     description: |-
       For __non-App Store__ exports, should Xcode re-compile the app from bitcode?
     value_options:
@@ -75,7 +76,7 @@ inputs:
 - upload_bitcode: "yes"
   opts:
     title: "Include bitcode"
-    summary: ""
+    summary: "For __App Store__ exports, should the package include bitcode?"
     description: |-
       For __App Store__ exports, should the package include bitcode?
     value_options:

--- a/step.yml
+++ b/step.yml
@@ -84,7 +84,7 @@ inputs:
     - "no"
     is_required: true
 
-- custom_export_options_plist_content:
+- export_options_plist_content:
   opts:
     category: IPA export configuration
     title: Export options plist content

--- a/step.yml
+++ b/step.yml
@@ -34,10 +34,8 @@ inputs:
 
 - product: "app"
   opts:
-    title: "Select a product to distribute"
-    summary: ""
-    description: |-
-      Describes which product to export.
+    title: Select a product to distribute
+    summary: Describes which product to export.
     value_options:
     - "app"
     - "app-clip"
@@ -45,10 +43,8 @@ inputs:
 
 - distribution_method:
   opts:
-    title: "Distribution method"
-    summary: "Describes how Xcode should export the archive."
-    description: |-
-      Describes how Xcode should export the archive.
+    title: Distribution method
+    summary: Describes how Xcode should export the archive.
     value_options:
     - "development"
     - "app-store"
@@ -60,21 +56,19 @@ inputs:
 
 - export_development_team:
   opts:
-    category: "IPA export configuration"
-    title: "Developer Portal team"
-    summary: "The Developer Portal team to use for this export"
+    category: IPA export configuration
+    title: Developer Portal team
+    summary: The Developer Portal team to use for this export
     description: |-
       The Developer Portal team to use for this export.
 
-      Format example: `1MZX23ABCD4`
+      Format example: '1MZX23ABCD4'
 
 - compile_bitcode: "yes"
   opts:
-    category: "IPA export configuration"
-    title: "Rebuild from bitcode"
-    summary: "For __non-App Store__ exports, should Xcode re-compile the app from bitcode?"
-    description: |-
-      For __non-App Store__ exports, should Xcode re-compile the app from bitcode?
+    category: IPA export configuration
+    title: Rebuild from bitcode
+    summary: For __non-App Store__ exports, should Xcode re-compile the app from bitcode?
     value_options:
     - "yes"
     - "no"
@@ -82,11 +76,9 @@ inputs:
 
 - upload_bitcode: "yes"
   opts:
-    category: "IPA export configuration"
-    title: "Include bitcode"
-    summary: "For __App Store__ exports, should the package include bitcode?"
-    description: |-
-      For __App Store__ exports, should the package include bitcode?
+    category: IPA export configuration
+    title: Include bitcode
+    summary: For __App Store__ exports, should the package include bitcode?
     value_options:
     - "yes"
     - "no"
@@ -94,9 +86,9 @@ inputs:
 
 - custom_export_options_plist_content:
   opts:
-    category: "IPA export configuration"
-    title: "Export options plist content"
-    summary: "Specifies a plist file content that configures archive exporting."
+    category: IPA export configuration
+    title: Export options plist content
+    summary: Specifies a plist file content that configures archive exporting.
     description: |-
       Specifies a custom export options plist content that configures archive exporting.
       If empty, step generates these options based on the embedded provisioning profile,
@@ -108,8 +100,8 @@ inputs:
 
 - verbose_log: "yes"
   opts:
-    category: "Debugging"
-    title: "Enable verbose logging?"
+    category: Debugging
+    title: Enable verbose logging?
     description: Enable verbose logging?
     is_required: true
     value_options:

--- a/step.yml
+++ b/step.yml
@@ -29,7 +29,7 @@ inputs:
     description: |-
       Specifies the archive that should be exported.
 
-      The input value sets xcodebuild’s '-archivePath' option.
+      The input value sets xcodebuild's `-archivePath` option.
     is_required: true
 
 - product: "app"

--- a/step.yml
+++ b/step.yml
@@ -6,124 +6,112 @@ website: https://github.com/bitrise-steplib/steps-export-xcarchive
 source_code_url: https://github.com/bitrise-steplib/steps-export-xcarchive
 support_url: https://github.com/bitrise-steplib/steps-export-xcarchive/issues
 host_os_tags:
-  - osx-10.10
+- osx-10.10
 project_type_tags:
-  - ios
-  - cordova
-  - ionic
-  - react-native
-  - flutter
-  - xamarin
+- ios
+- cordova
+- ionic
+- react-native
+- flutter
+- xamarin
 type_tags:
-  - utility
+- utility
 is_always_run: false
 is_skippable: false
 toolkit:
   go:
     package_name: github.com/bitrise-steplib/steps-export-xcarchive
 inputs:
-  - archive_path: $BITRISE_XCARCHIVE_PATH
-    opts:
-      title: iOS or tvOS archive path
-      summary: iOS or tvOS archive path
-      description: |-
-        Path to the iOS or tvOS archive (.xcarchive) which should be exported.
-      is_required: true
-  - export_method: "auto-detect"
-    opts:
-      title: "Select method for export"
-      summary: ""
-      description: |-
-        `auto-detect` option is **DEPRECATED** - use direct export methods!
+- archive_path: $BITRISE_XCARCHIVE_PATH
+  opts:
+    title: iOS or tvOS archive path
+    summary: iOS or tvOS archive path
+    description: |-
+      Path to the iOS or tvOS archive (.xcarchive) which should be exported.
+    is_required: true
+- product: "app"
+  opts:
+    title: "Select a product to distribute"
+    summary: ""
+    description: |-
+      Describes which product to export.
+      Possible options are App or App Clip.
+    value_options:
+    - "app"
+    - "app-clip"
+    is_required: true
+- distribution_method:
+  opts:
+    title: "Distribution method"
+    summary: "Describes how Xcode should export the archive."
+    description: |-
+      Describes how Xcode should export the archive.
+    value_options:
+    - "development"
+    - "app-store"
+    - "ad-hoc"
+    - "enterprise"
+    is_required: true
+- export_development_team:
+  opts:
+    title: "Developer Portal team"
+    summary: "The Developer Portal team to use for this export"
+    description: |-
+      The Developer Portal team to use for this export.
 
-        Describes how Xcode should export the archive.   
-        
-        If you select `auto-detect`, the step will figure out the proper export method  
-        based on the provisioning profile embedded into the generated xcode archive.
-      value_options:
-      - "auto-detect"
-      - "app-store"
-      - "ad-hoc"
-      - "enterprise"
-      - "development"
-      is_required: true
-  - upload_bitcode: "yes"
-    opts:
-      title: "Include bitcode"
-      summary: ""
-      description: |-
-        For __App Store__ exports, should the package include bitcode?
-      value_options:
-      - "yes"
-      - "no"
-      is_required: true
-  - compile_bitcode: "yes"
-    opts:
-      title: "Rebuild from bitcode"
-      summary: ""
-      description: |-
-        For __non-App Store__ exports, should Xcode re-compile the app from bitcode?
-      value_options:
-      - "yes"
-      - "no"
-      is_required: true
-  - team_id: 
-    opts:
-      title: "The Developer Portal team to use for this export"
-      summary: ""
-      description: |-
-        The Developer Portal team to use for this export.
+      Format example: `1MZX23ABCD4`
+    category: "IPA export configuration"
+- compile_bitcode: "yes"
+  opts:
+    title: "Rebuild from bitcode"
+    summary: ""
+    description: |-
+      For __non-App Store__ exports, should Xcode re-compile the app from bitcode?
+    value_options:
+    - "yes"
+    - "no"
+    is_required: true
+    category: "IPA export configuration"
+- upload_bitcode: "yes"
+  opts:
+    title: "Include bitcode"
+    summary: ""
+    description: |-
+      For __App Store__ exports, should the package include bitcode?
+    value_options:
+    - "yes"
+    - "no"
+    is_required: true
+    category: "IPA export configuration"
+- custom_export_options_plist_content:
+  opts:
+    title: "Export options plist content"
+    summary: "Specifies a plist file content that configures archive exporting."
+    description: |-
+      Specifies a custom export options plist content that configures archive exporting.
+      If empty, step generates these options based on the embedded provisioning profile,
+      with default values.
 
-        Format example:
-
-        - `1MZX23ABCD4`
-  - product: "app"
-    opts:
-      title: "Select a product to distribute"
-      summary: ""
-      description: |-
-        Describes which product to export.   
-        Possible options are App or App Clip.
-      value_options:
-      - "app"
-      - "app-clip"
-      is_required: true
-  - custom_export_options_plist_content:
-    opts:
-      title: "Custom export options plist content"
-      description: |-
-        Specifies a custom export options plist content that configures archive exporting.
-        If empty, step generates these options based on the embedded provisioning profile,
-        with default values.
-
-        Auto generated export options available for export methods:
-
-        - app-store
-        - ad-hoc
-        - enterprise
-        - development
-
-        If step doesn't find export method based on provisioning profile, development will be use.
-
-        Call `xcodebuild -help` for available export options.
-  - verbose_log: "yes"
-    opts:
-      category: Debug
-      title: "Enable verbose logging?"
-      description: Enable verbose logging?
-      is_required: true
-      value_options:
-      - "yes"
-      - "no"
+      Call `xcodebuild -help` for available export options.
+    category: "IPA export configuration"
+- verbose_log: "yes"
+  opts:
+    category: "Debugging"
+    title: "Enable verbose logging?"
+    description: Enable verbose logging?
+    is_required: true
+    value_options:
+    - "yes"
+    - "no"
 outputs:
-  - BITRISE_IPA_PATH:
-    opts:
-      title: The created iOS or tvOS .ipa file's path.
-  - BITRISE_DSYM_PATH:
-    opts:
-      title: The created iOS or tvOS .dSYM zip file's path.
-      description: |-
-        Step will collect every dsym (app dsym and framwork dsyms) in a directory, zip it and export the zipped directory path.
-  - BITRISE_IDEDISTRIBUTION_LOGS_PATH:
-    opts:
-      title: Path to the xcdistributionlogs zip
+- BITRISE_IPA_PATH:
+  opts:
+    title: The created iOS or tvOS .ipa file's path.
+- BITRISE_DSYM_PATH:
+  opts:
+    title: The created iOS or tvOS .dSYM zip file's path.
+    description: |-
+      Step will collect every dsym (app dsym and framwork dsyms) in a directory, zip it and export the zipped directory path.
+- BITRISE_IDEDISTRIBUTION_LOGS_PATH:
+  opts:
+    title: Path to the xcdistributionlogs zip

--- a/step.yml
+++ b/step.yml
@@ -29,7 +29,7 @@ inputs:
     description: |-
       Specifies the archive that should be exported.
 
-    The input value sets `xcodebuild`’s `-archivePath` option.
+      The input value sets xcodebuild’s '-archivePath' option.
     is_required: true
 
 - product: "app"
@@ -94,7 +94,7 @@ inputs:
       If empty, step generates these options based on the embedded provisioning profile,
       with default values.
 
-      Call `xcodebuild -help` for available export options.
+      Call 'xcodebuild -help' for available export options.
 
 # Debugging
 

--- a/step.yml
+++ b/step.yml
@@ -60,16 +60,17 @@ inputs:
 
 - export_development_team:
   opts:
+    category: "IPA export configuration"
     title: "Developer Portal team"
     summary: "The Developer Portal team to use for this export"
     description: |-
       The Developer Portal team to use for this export.
 
       Format example: `1MZX23ABCD4`
-    category: "IPA export configuration"
 
 - compile_bitcode: "yes"
   opts:
+    category: "IPA export configuration"
     title: "Rebuild from bitcode"
     summary: "For __non-App Store__ exports, should Xcode re-compile the app from bitcode?"
     description: |-
@@ -78,9 +79,10 @@ inputs:
     - "yes"
     - "no"
     is_required: true
-    category: "IPA export configuration"
+
 - upload_bitcode: "yes"
   opts:
+    category: "IPA export configuration"
     title: "Include bitcode"
     summary: "For __App Store__ exports, should the package include bitcode?"
     description: |-
@@ -89,10 +91,10 @@ inputs:
     - "yes"
     - "no"
     is_required: true
-    category: "IPA export configuration"
 
 - custom_export_options_plist_content:
   opts:
+    category: "IPA export configuration"
     title: "Export options plist content"
     summary: "Specifies a plist file content that configures archive exporting."
     description: |-
@@ -101,7 +103,6 @@ inputs:
       with default values.
 
       Call `xcodebuild -help` for available export options.
-    category: "IPA export configuration"
 
 # Debugging
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR* [version update](https://semver.org/)

### Context

Unification of Xcode-related step inputs.

### Changes

- Rename `export_method` to `distribution_method`
- Remove deprecated default value of `export_method` (`auto-detect`)
- Reorder inputs
- Arrange inputs into categories

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
