### PR TITLE
Add option to set manage version and build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,35 @@ Export iOS and tvOS IPA from an existing Xcode archive
 <details>
 <summary>Description</summary>
 
-Exports an IPA from an existing iOS and tvOS `.xcarchive` file.
+Exports an IPA from an existing iOS and tvOS `.xcarchive` file. You can add multiple **Export iOS and tvOS Xcode archive** Steps to your Workflows to create multiple different signed .ipa files.
+The Step also logs you into your Apple Developer account based on the [Apple service connection you provide on Bitrise](https://devcenter.bitrise.io/en/accounts/connecting-to-services/apple-services-connection.html) and downloads any provisioning profiles needed for your project based on the **Distribution method**.
+
+### Configuring the Step
+Before you start:
+- Make sure you have connected your [Apple Service account to Bitrise](https://devcenter.bitrise.io/en/accounts/connecting-to-services/apple-services-connection.html).
+Alternatively, you can upload certificates and profiles to Bitrise manually, then use the Certificate and Profile installer step before Xcode Archive
+- Make sure certificates are uploaded to Bitrise's **Code Signing** tab. The right provisioning profiles are automatically downloaded from Apple as part of the automatic code signing process.
+
+To configure the Step:
+1. **Archive Path**: Specifies the archive that should be exported. The input value sets xcodebuild's `-archivePath` option.
+2. **Select a product to distribute**: Decide if an App or an App Clip IPA should be exported.
+3. **Distribution method**: Describes how Xcode should export the archive: development, app-store, ad-hoc, or enterprise.
+
+Under **Automatic code signing**:
+1. **Automatic code signing method**: Select the Apple service connection you want to use for code signing. Available options: `off` if you don't do automatic code signing, `api-key` [if you use API key authorization](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-api-key.html), and `apple-id` [if you use Apple ID authorization](https://devcenter.bitrise.io/en/accounts/connecting-to-services/connecting-to-an-apple-service-with-apple-id.html).
+2. **Register test devices on the Apple Developer Portal**: If this input is set, the Step will register the known test devices on Bitrise from team members with the Apple Developer Portal. Note that setting this to `yes` may cause devices to be registered against your limited quantity of test devices in the Apple Developer Portal, which can only be removed once annually during your renewal window.
+3. **The minimum days the Provisioning Profile should be valid**: If this input is set to >0, the managed Provisioning Profile will be renewed if it expires within the configured number of days. Otherwise the Step renews the managed Provisioning Profile if it is expired.
+4. The **Code signing certificate URL**, the **Code signing certificate passphrase**, the **Keychain path**, and the **Keychain password** inputs are automatically populated if certificates are uploaded to Bitrise's **Code Signing** tab. If you store your files in a private repo, you can manually edit these fields.
+
+Under **IPA export configuration**:
+1. **Developer Portal team**: Add the Developer Portal team's name to use for this export. This input defaults to the team used to build the archive.
+2. **Rebuild from bitcode**: For non-App Store exports, should Xcode re-compile the app from bitcode?
+3. **Include bitcode**: For App Store exports, should the package include bitcode?
+4. **iCloud container environment**: If the app is using CloudKit, this input configures the `com.apple.developer.icloud-container-environment` entitlement. Available options vary depending on the type of provisioning profile used, but may include: `Development` and `Production`.
+5. **Export options plist content**: Specifies a `plist` file content that configures archive exporting. If not specified, the Step will auto-generate it.
+
+Under Debugging:
+1. **Verbose logging***: You can set this input to `yes` to produce more informative logs.
 </details>
 
 ## 🧩 Get started
@@ -55,6 +83,7 @@ steps:
 | `export_development_team` | The Developer Portal team to use for this export.  Defaults to the team used to build the archive. |  |  |
 | `compile_bitcode` | For __non-App Store__ exports, should Xcode re-compile the app from bitcode? | required | `yes` |
 | `upload_bitcode` | For __App Store__ exports, should the package include bitcode? | required | `yes` |
+| `manage_version_and_build_number` | Should Xcode manage the app's build number when uploading to App Store Connect. This will change the version and build numbers of all content in your app only if the is an invalid number (like one that was used previously or precedes your current build number). The input will not work if `export options plist content` input has been set. Default set to No. | required | `no` |
 | `export_options_plist_content` | Specifies a plist file content that configures archive exporting.  If not specified, the Step will auto-generate it. |  |  |
 | `verbose_log` | If this input is set, the Step will print additional logs for debugging. | required | `no` |
 </details>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -24,8 +24,15 @@ workflows:
         - branch: master
     - path::./:
         title: Step Test - iOS archive
+        is_always_run: true
         inputs:
         - export_method: development
+        - archive_path: ./archives/ios.xcarchive
+    - path::./:
+        title: Step Test - iOS archive
+        is_always_run: true
+        inputs:
+        - export_method: app-store
         - archive_path: ./archives/ios.xcarchive
 
   check:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -29,7 +29,7 @@ workflows:
         - export_method: development
         - archive_path: ./archives/ios.xcarchive
     - path::./:
-        title: Step Test - iOS archive
+        title: Step Test - iOS app store archive
         is_always_run: true
         inputs:
         - export_method: app-store

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils v0.0.0-20211205220451-e046db274afb
 	github.com/bitrise-io/go-utils v0.0.0-20211126092127-3a566ee3f420
 	github.com/bitrise-io/go-xcode v0.0.0-20211203163621-99a08cd4c73d
-	github.com/bitrise-steplib/steps-xcode-archive v0.0.0-20211203160404-d347ed2b37a4
+	github.com/bitrise-steplib/steps-xcode-archive v0.0.0-20211206161837-eb2baab896e6
 	howett.net/plist v1.0.0
 )
 
@@ -14,6 +14,7 @@ require (
 	github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10 // indirect
 	github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXs
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/bitrise-steplib/steps-xcode-archive v0.0.0-20211203160404-d347ed2b37a4 h1:6rvSsXVZUt3tcIL77kMXNOasD/tWY4jwo2cCTgmavJM=
 github.com/bitrise-steplib/steps-xcode-archive v0.0.0-20211203160404-d347ed2b37a4/go.mod h1:Zb3dRgspZ+tvPnArJR3cIEFmBiJAGzVwssVqirNkUKY=
+github.com/bitrise-steplib/steps-xcode-archive v0.0.0-20211206161837-eb2baab896e6 h1:zqWo1Oa+sa2tHV2RXm3fvSBUZ8d6JhxW56ewbI1ouDk=
+github.com/bitrise-steplib/steps-xcode-archive v0.0.0-20211206161837-eb2baab896e6/go.mod h1:0h88azECrVCz3Rqn3rVD+efqpY7HugNrLAqsr7mfqSI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -62,12 +64,14 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/main.go
+++ b/main.go
@@ -55,10 +55,11 @@ type Inputs struct {
 	BuildURL                  string          `env:"BITRISE_BUILD_URL"`
 	BuildAPIToken             stepconf.Secret `env:"BITRISE_BUILD_API_TOKEN"`
 	// IPA export configuration
-	TeamID                    string `env:"export_development_team"`
-	CompileBitcode            bool   `env:"compile_bitcode,opt[yes,no]"`
-	UploadBitcode             bool   `env:"upload_bitcode,opt[yes,no]"`
-	ExportOptionsPlistContent string `env:"export_options_plist_content"`
+	TeamID                      string `env:"export_development_team"`
+	CompileBitcode              bool   `env:"compile_bitcode,opt[yes,no]"`
+	UploadBitcode               bool   `env:"upload_bitcode,opt[yes,no]"`
+	ManageVersionAndBuildNumber bool   `env:"manage_version_and_build_number"`
+	ExportOptionsPlistContent   string `env:"export_options_plist_content"`
 	// Debugging
 	VerboseLog bool `env:"verbose_log,opt[yes,no]"`
 	// Output export
@@ -318,10 +319,12 @@ func (s Step) Run(opts Config) (RunOut, error) {
 			return RunOut{}, fmt.Errorf("failed to write export options to file, error: %s", err)
 		}
 	} else {
-		exportOptionsContent, err := generateExportOptionsPlist(opts.ProductToDistribute, opts.DistributionMethod, opts.TeamID, opts.UploadBitcode, opts.CompileBitcode, opts.XcodebuildVersion.MajorVersion, archive)
+		exportOptionsContent, err := generateExportOptionsPlist(opts.ProductToDistribute, opts.DistributionMethod, opts.TeamID, opts.UploadBitcode, opts.CompileBitcode, opts.XcodebuildVersion.MajorVersion, archive, opts.ManageVersionAndBuildNumber)
 		if err != nil {
 			return RunOut{}, fmt.Errorf("failed to generate export options, error: %s", err)
 		}
+
+		log.Warnf("path %s", exportOptionsPath)
 
 		log.Printf("\ngenerated export options content:\n%s", exportOptionsContent)
 

--- a/main.go
+++ b/main.go
@@ -326,7 +326,7 @@ func (s Step) Run(opts Config) (RunOut, error) {
 			return RunOut{}, fmt.Errorf("failed to generate export options, error: %s", err)
 		}
 
-		log.Warnf("path %s", exportOptionsPath)
+		log.Debugf("path %s", exportOptionsPath)
 
 		log.Printf("\ngenerated export options content:\n%s", exportOptionsContent)
 

--- a/main.go
+++ b/main.go
@@ -326,8 +326,6 @@ func (s Step) Run(opts Config) (RunOut, error) {
 			return RunOut{}, fmt.Errorf("failed to generate export options, error: %s", err)
 		}
 
-		log.Debugf("path %s", exportOptionsPath)
-
 		log.Printf("\ngenerated export options content:\n%s", exportOptionsContent)
 
 		if err := fileutil.WriteStringToFile(exportOptionsPath, exportOptionsContent); err != nil {

--- a/main.go
+++ b/main.go
@@ -67,16 +67,18 @@ type Inputs struct {
 }
 
 type Config struct {
-	ArchivePath               string
-	DeployDir                 string
-	ProductToDistribute       ExportProduct
-	ExportOptionsPlistContent string
-	DistributionMethod        string
-	TeamID                    string
-	UploadBitcode             bool
-	CompileBitcode            bool
-	XcodebuildVersion         models.XcodebuildVersionModel
-	CodesignManager           *codesign.Manager // nil if automatic code signing is "off"
+	ArchivePath                 string
+	DeployDir                   string
+	ProductToDistribute         ExportProduct
+	ExportOptionsPlistContent   string
+	DistributionMethod          string
+	TeamID                      string
+	UploadBitcode               bool
+	CompileBitcode              bool
+	ManageVersionAndBuildNumber bool
+	XcodebuildVersion           models.XcodebuildVersionModel
+	CodesignManager             *codesign.Manager // nil if automatic code signing is "off"
+	VerboseLog                  bool
 }
 
 type RunOut struct {

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -10,77 +9,6 @@ import (
 	"github.com/bitrise-io/go-xcode/utility"
 	"github.com/bitrise-io/go-xcode/xcarchive"
 )
-
-func TestConfig_validate(t *testing.T) {
-	type fields struct {
-		ArchivePath                     string
-		ExportMethod                    string
-		UploadBitcode                   bool
-		CompileBitcode                  bool
-		TeamID                          string
-		CustomExportOptionsPlistContent string
-		UseLegacyExport                 bool
-		DeployDir                       string
-		VerboseLog                      bool
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		want    fields
-		wantErr bool
-	}{
-		{
-			name: "TeamID contains whitespace",
-			fields: fields{
-				TeamID: "  ",
-			},
-			want: fields{
-				TeamID: "",
-			},
-			wantErr: false,
-		},
-		{
-			name: "ExportOptionsPlistContent contains whitespace",
-			fields: fields{
-				CustomExportOptionsPlistContent: "  ",
-			},
-			want: fields{
-				CustomExportOptionsPlistContent: "",
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configs := &Config{
-				ArchivePath:               tt.fields.ArchivePath,
-				DistributionMethod:        tt.fields.ExportMethod,
-				UploadBitcode:             tt.fields.UploadBitcode,
-				CompileBitcode:            tt.fields.CompileBitcode,
-				TeamID:                    tt.fields.TeamID,
-				ExportOptionsPlistContent: tt.fields.CustomExportOptionsPlistContent,
-				DeployDir:                 tt.fields.DeployDir,
-				VerboseLog:                tt.fields.VerboseLog,
-			}
-			wantConfigs := &Config{
-				ArchivePath:               tt.want.ArchivePath,
-				DistributionMethod:        tt.want.ExportMethod,
-				UploadBitcode:             tt.want.UploadBitcode,
-				CompileBitcode:            tt.want.CompileBitcode,
-				TeamID:                    tt.want.TeamID,
-				ExportOptionsPlistContent: tt.want.CustomExportOptionsPlistContent,
-				DeployDir:                 tt.want.DeployDir,
-				VerboseLog:                tt.want.VerboseLog,
-			}
-			if err := configs.validate(); (err != nil) != tt.wantErr {
-				t.Errorf("Config.validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if !reflect.DeepEqual(configs, wantConfigs) {
-				t.Errorf("Config.validate() configs = %+v, wantConfig = %+v", configs, wantConfigs)
-			}
-		})
-	}
-}
 
 func TestConfig_generateExportOptions_plist(t *testing.T) {
 	// Given
@@ -96,11 +24,9 @@ func TestConfig_generateExportOptions_plist(t *testing.T) {
 	if len(result) == 0 {
 		t.Errorf("plist is empty")
 	}
-
-	print("%s", result)
 }
 
-func TestConfig_generateExportOptions_plistValidField(t *testing.T) {
+func TestConfig_generateExportOptions_plist_validField(t *testing.T) {
 	// Given
 	envRepository := env.NewRepository()
 	commandFactory := command.NewFactory(envRepository)
@@ -125,5 +51,25 @@ func TestConfig_generateExportOptions_plistValidField(t *testing.T) {
 
 	if strings.Contains(result, "development") == false {
 		t.Errorf("plist does not contain development value for method field")
+	}
+}
+
+func TestConfig_generateExportOptions_plist_updateVersionAndBuildSetToFalse(t *testing.T) {
+	// Given
+	envRepository := env.NewRepository()
+	commandFactory := command.NewFactory(envRepository)
+	xcodebuildVersion, _ := utility.GetXcodeVersion(commandFactory)
+	archive, _ := xcarchive.NewIosArchive("configs.ArchivePath")
+
+	// When
+	result, err := generateExportOptionsPlist("app", "app-store", "my team id", false, false, xcodebuildVersion.MajorVersion, archive, false)
+
+	// Then
+	if err != nil {
+		t.Errorf("generate export options plist error")
+	}
+
+	if strings.Contains(result, "manageAppVersionAndBuildNumber") == false {
+		t.Errorf("plist does not contain manage app version and build number value for method field")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -69,7 +69,7 @@ func TestConfig_generateExportOptions_plist_updateVersionAndBuildSetToFalse(t *t
 		t.Errorf("generate export options plist error")
 	}
 
-	if strings.Contains(result, "manageAppVersionAndBuildNumber") == false {
+	if xcodebuildVersion.MajorVersion > 12 && strings.Contains(result, "manageAppVersionAndBuildNumber") == false {
 		t.Errorf("plist does not contain manage app version and build number value for method field")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/go-utils/env"
 	"github.com/bitrise-io/go-xcode/utility"
 	"github.com/bitrise-io/go-xcode/xcarchive"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfig_generateExportOptions_plist(t *testing.T) {
@@ -24,6 +25,8 @@ func TestConfig_generateExportOptions_plist(t *testing.T) {
 	if len(result) == 0 {
 		t.Errorf("plist is empty")
 	}
+
+	assert.NotEqual(t, 0, len(result))
 }
 
 func TestConfig_generateExportOptions_plist_validField(t *testing.T) {
@@ -37,21 +40,10 @@ func TestConfig_generateExportOptions_plist_validField(t *testing.T) {
 	result, err := generateExportOptionsPlist("app", "development", "my team id", false, false, xcodebuildVersion.MajorVersion, archive, true)
 
 	// Then
-	if err != nil {
-		t.Errorf("generate export options plist error")
-	}
-
-	if strings.Contains(result, "compileBitcode") == false {
-		t.Errorf("plist does not contain compile bitcode field")
-	}
-
-	if strings.Contains(result, "method") == false {
-		t.Errorf("plist does not contain method field")
-	}
-
-	if strings.Contains(result, "development") == false {
-		t.Errorf("plist does not contain development value for method field")
-	}
+	assert.Nil(t, err)
+	assert.Contains(t, result, "compileBitcode")
+	assert.Contains(t, result, "method")
+	assert.Contains(t, result, "development")
 }
 
 func TestConfig_generateExportOptions_plist_updateVersionAndBuildSetToFalse(t *testing.T) {
@@ -65,9 +57,7 @@ func TestConfig_generateExportOptions_plist_updateVersionAndBuildSetToFalse(t *t
 	result, err := generateExportOptionsPlist("app", "app-store", "my team id", false, false, xcodebuildVersion.MajorVersion, archive, false)
 
 	// Then
-	if err != nil {
-		t.Errorf("generate export options plist error")
-	}
+	assert.Nil(t, err)
 
 	if xcodebuildVersion.MajorVersion > 12 && strings.Contains(result, "manageAppVersionAndBuildNumber") == false {
 		t.Errorf("plist does not contain manage app version and build number value for method field")

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/env"
+	"github.com/bitrise-io/go-xcode/utility"
+	"github.com/bitrise-io/go-xcode/xcarchive"
+)
+
+func TestConfig_validate(t *testing.T) {
+	type fields struct {
+		ArchivePath                     string
+		ExportMethod                    string
+		UploadBitcode                   bool
+		CompileBitcode                  bool
+		TeamID                          string
+		CustomExportOptionsPlistContent string
+		UseLegacyExport                 bool
+		DeployDir                       string
+		VerboseLog                      bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    fields
+		wantErr bool
+	}{
+		{
+			name: "TeamID contains whitespace",
+			fields: fields{
+				TeamID: "  ",
+			},
+			want: fields{
+				TeamID: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "ExportOptionsPlistContent contains whitespace",
+			fields: fields{
+				CustomExportOptionsPlistContent: "  ",
+			},
+			want: fields{
+				CustomExportOptionsPlistContent: "",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configs := &Config{
+				ArchivePath:               tt.fields.ArchivePath,
+				DistributionMethod:        tt.fields.ExportMethod,
+				UploadBitcode:             tt.fields.UploadBitcode,
+				CompileBitcode:            tt.fields.CompileBitcode,
+				TeamID:                    tt.fields.TeamID,
+				ExportOptionsPlistContent: tt.fields.CustomExportOptionsPlistContent,
+				DeployDir:                 tt.fields.DeployDir,
+				VerboseLog:                tt.fields.VerboseLog,
+			}
+			wantConfigs := &Config{
+				ArchivePath:               tt.want.ArchivePath,
+				DistributionMethod:        tt.want.ExportMethod,
+				UploadBitcode:             tt.want.UploadBitcode,
+				CompileBitcode:            tt.want.CompileBitcode,
+				TeamID:                    tt.want.TeamID,
+				ExportOptionsPlistContent: tt.want.CustomExportOptionsPlistContent,
+				DeployDir:                 tt.want.DeployDir,
+				VerboseLog:                tt.want.VerboseLog,
+			}
+			if err := configs.validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Config.validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(configs, wantConfigs) {
+				t.Errorf("Config.validate() configs = %+v, wantConfig = %+v", configs, wantConfigs)
+			}
+		})
+	}
+}
+
+func TestConfig_generateExportOptions_plist(t *testing.T) {
+	// Given
+	envRepository := env.NewRepository()
+	commandFactory := command.NewFactory(envRepository)
+	xcodebuildVersion, _ := utility.GetXcodeVersion(commandFactory)
+	archive, _ := xcarchive.NewIosArchive("configs.ArchivePath")
+
+	// When
+	result, _ := generateExportOptionsPlist("app", "development", "my team id", false, false, xcodebuildVersion.MajorVersion, archive, false)
+
+	// Then
+	if len(result) == 0 {
+		t.Errorf("plist is empty")
+	}
+
+	print("%s", result)
+}
+
+func TestConfig_generateExportOptions_plistValidField(t *testing.T) {
+	// Given
+	envRepository := env.NewRepository()
+	commandFactory := command.NewFactory(envRepository)
+	xcodebuildVersion, _ := utility.GetXcodeVersion(commandFactory)
+	archive, _ := xcarchive.NewIosArchive("configs.ArchivePath")
+
+	// When
+	result, err := generateExportOptionsPlist("app", "development", "my team id", false, false, xcodebuildVersion.MajorVersion, archive, true)
+
+	// Then
+	if err != nil {
+		t.Errorf("generate export options plist error")
+	}
+
+	if strings.Contains(result, "compileBitcode") == false {
+		t.Errorf("plist does not contain compile bitcode field")
+	}
+
+	if strings.Contains(result, "method") == false {
+		t.Errorf("plist does not contain method field")
+	}
+
+	if strings.Contains(result, "development") == false {
+		t.Errorf("plist does not contain development value for method field")
+	}
+}

--- a/step.yml
+++ b/step.yml
@@ -206,7 +206,7 @@ inputs:
     value_options:
     - "yes"
     - "no"
-    is_required: false
+    is_required: true
 
 - export_options_plist_content:
   opts:

--- a/step.yml
+++ b/step.yml
@@ -174,7 +174,7 @@ inputs:
   opts:
     category: IPA export configuration
     title: Manage version and build number
-    summary: This will change the version and build number of all content in your app. If your app has an invalid number (like one that was used previously, or precedes your current build number), the step provides an option to automatically increment it to a valid number. Step does not work if export options plist content has been set. 
+    summary: This will change the version and build number of all content in your app. If your app has an invalid number (like one that was used previously, or precedes your current build number), the step provides an option to automatically increment it to a valid number. Step does not work if export options plist content has been set.
     value_options:
     - "yes"
     - "no"

--- a/step.yml
+++ b/step.yml
@@ -201,8 +201,8 @@ inputs:
 - manage_version_and_build_number: "no"
   opts:
     category: IPA export configuration
-    title: Manage version and build number
-    summary: This will change the version and build number of all content in your app. If your app has an invalid number (like one that was used previously, or precedes your current build number), the step provides an option to automatically increment it to a valid number. The step does not work if export options plist content has been set.
+    title: Xcode manage version and build number (App Store Connect)
+    summary: Should Xcode manage the app's build number when uploading to App Store Connect. This will change the version and build numbers of all content in your app only if the is an invalid number (like one that was used previously or precedes your current build number). The input will not work if `export options plist content` input has been set. Default set to No.
     value_options:
     - "yes"
     - "no"

--- a/step.yml
+++ b/step.yml
@@ -202,7 +202,7 @@ inputs:
   opts:
     category: IPA export configuration
     title: Manage version and build number
-    summary: This will change the version and build number of all content in your app. If your app has an invalid number (like one that was used previously, or precedes your current build number), the step provides an option to automatically increment it to a valid number. Step does not work if export options plist content has been set.
+    summary: This will change the version and build number of all content in your app. If your app has an invalid number (like one that was used previously, or precedes your current build number), the step provides an option to automatically increment it to a valid number. The step does not work if export options plist content has been set.
     value_options:
     - "yes"
     - "no"

--- a/step.yml
+++ b/step.yml
@@ -170,6 +170,16 @@ inputs:
     - "no"
     is_required: true
 
+- manage_version_and_build_number: "no"
+  opts:
+    category: IPA export configuration
+    title: Manage version and build number
+    summary: This will change the version and build number of all content in your app. If your app has an invalid number (like one that was used previously, or precedes your current build number), the step provides an option to automatically increment it to a valid number. Step does not work if export options plist content has been set. 
+    value_options:
+    - "yes"
+    - "no"
+    is_required: false
+
 - export_options_plist_content:
   opts:
     category: IPA export configuration

--- a/utils.go
+++ b/utils.go
@@ -56,7 +56,7 @@ func findIDEDistrubutionLogsPath(output string) (string, error) {
 	return "", nil
 }
 
-func generateExportOptionsPlist(exportProduct ExportProduct, exportMethodStr, teamID string, uploadBitcode, compileBitcode bool, xcodebuildMajorVersion int64, archive xcarchive.IosArchive) (string, error) {
+func generateExportOptionsPlist(exportProduct ExportProduct, exportMethodStr, teamID string, uploadBitcode, compileBitcode bool, xcodebuildMajorVersion int64, archive xcarchive.IosArchive, manageVersionAndBuildNumber bool) (string, error) {
 	log.Printf("Generating export options")
 
 	var productBundleID string
@@ -271,6 +271,12 @@ func generateExportOptionsPlist(exportProduct ExportProduct, exportMethodStr, te
 
 				options.SigningStyle = "manual"
 			}
+		}
+
+		if xcodebuildMajorVersion >= 13 {
+			log.Debugf("Setting flag for managing app version and build number")
+
+			options.ManageAppVersion = manageVersionAndBuildNumber
 		}
 
 		exportOpts = options

--- a/vendor/github.com/bitrise-io/go-plist/go.mod
+++ b/vendor/github.com/bitrise-io/go-plist/go.mod
@@ -1,0 +1,9 @@
+module github.com/bitrise-io/go-plist
+
+go 1.15
+
+require (
+	github.com/jessevdk/go-flags v1.4.0
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
+)

--- a/vendor/github.com/bitrise-io/go-plist/go.sum
+++ b/vendor/github.com/bitrise-io/go-plist/go.sum
@@ -1,0 +1,11 @@
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=

--- a/vendor/github.com/golang-jwt/jwt/v4/go.mod
+++ b/vendor/github.com/golang-jwt/jwt/v4/go.mod
@@ -1,0 +1,3 @@
+module github.com/golang-jwt/jwt/v4
+
+go 1.15

--- a/vendor/github.com/hashicorp/go-cleanhttp/go.mod
+++ b/vendor/github.com/hashicorp/go-cleanhttp/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/go-cleanhttp
+
+go 1.13

--- a/vendor/github.com/hashicorp/go-retryablehttp/go.mod
+++ b/vendor/github.com/hashicorp/go-retryablehttp/go.mod
@@ -1,0 +1,8 @@
+module github.com/hashicorp/go-retryablehttp
+
+require (
+	github.com/hashicorp/go-cleanhttp v0.5.1
+	github.com/hashicorp/go-hclog v0.9.2
+)
+
+go 1.13

--- a/vendor/github.com/hashicorp/go-retryablehttp/go.sum
+++ b/vendor/github.com/hashicorp/go-retryablehttp/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/vendor/github.com/hashicorp/go-version/go.mod
+++ b/vendor/github.com/hashicorp/go-version/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/go-version

--- a/vendor/github.com/ryanuber/go-glob/go.mod
+++ b/vendor/github.com/ryanuber/go-glob/go.mod
@@ -1,0 +1,1 @@
+module github.com/ryanuber/go-glob

--- a/vendor/github.com/stretchr/objx/go.mod
+++ b/vendor/github.com/stretchr/objx/go.mod
@@ -1,0 +1,8 @@
+module github.com/stretchr/objx
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/stretchr/testify v1.3.0
+)

--- a/vendor/github.com/stretchr/objx/go.sum
+++ b/vendor/github.com/stretchr/objx/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/vendor/gopkg.in/yaml.v3/go.mod
+++ b/vendor/gopkg.in/yaml.v3/go.mod
@@ -1,0 +1,5 @@
+module "gopkg.in/yaml.v3"
+
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)

--- a/vendor/howett.net/plist/go.mod
+++ b/vendor/howett.net/plist/go.mod
@@ -1,0 +1,10 @@
+module howett.net/plist
+
+go 1.12
+
+require (
+	// for cmd/ply
+	github.com/jessevdk/go-flags v1.4.0
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 // indirect
+	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
+)

--- a/vendor/howett.net/plist/go.sum
+++ b/vendor/howett.net/plist/go.sum
@@ -1,0 +1,6 @@
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,15 +1,15 @@
 # github.com/bitrise-io/go-plist v0.0.0-20210301100253-4b1a112ccd10
-## explicit; go 1.15
+## explicit
 github.com/bitrise-io/go-plist
 # github.com/bitrise-io/go-steputils v0.0.0-20211205220451-e046db274afb
-## explicit; go 1.16
+## explicit
 github.com/bitrise-io/go-steputils/input
 github.com/bitrise-io/go-steputils/output
 github.com/bitrise-io/go-steputils/ruby
 github.com/bitrise-io/go-steputils/stepconf
 github.com/bitrise-io/go-steputils/tools
 # github.com/bitrise-io/go-utils v0.0.0-20211126092127-3a566ee3f420
-## explicit; go 1.16
+## explicit
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command
 github.com/bitrise-io/go-utils/env
@@ -27,7 +27,7 @@ github.com/bitrise-io/go-utils/sliceutil
 github.com/bitrise-io/go-utils/stringutil
 github.com/bitrise-io/go-utils/ziputil
 # github.com/bitrise-io/go-xcode v0.0.0-20211203163621-99a08cd4c73d
-## explicit; go 1.16
+## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/autocodesign
 github.com/bitrise-io/go-xcode/autocodesign/certdownloader
@@ -59,26 +59,28 @@ github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace
 ## explicit
 github.com/bitrise-io/pkcs12
 github.com/bitrise-io/pkcs12/internal/rc2
-# github.com/bitrise-steplib/steps-xcode-archive v0.0.0-20211203160404-d347ed2b37a4
-## explicit; go 1.16
+# github.com/bitrise-steplib/steps-xcode-archive v0.0.0-20211206161837-eb2baab896e6
+## explicit
 github.com/bitrise-steplib/steps-xcode-archive/utils
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
+# github.com/dgrijalva/jwt-go v3.2.0+incompatible
+## explicit
 # github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 ## explicit
 github.com/fullsailor/pkcs7
 # github.com/golang-jwt/jwt/v4 v4.2.0
-## explicit; go 1.15
+## explicit
 github.com/golang-jwt/jwt/v4
 # github.com/google/go-querystring v1.1.0
-## explicit; go 1.10
+## explicit
 github.com/google/go-querystring/query
 # github.com/hashicorp/go-cleanhttp v0.5.2
-## explicit; go 1.13
+## explicit
 github.com/hashicorp/go-cleanhttp
 # github.com/hashicorp/go-retryablehttp v0.7.0
-## explicit; go 1.13
+## explicit
 github.com/hashicorp/go-retryablehttp
 # github.com/hashicorp/go-version v1.3.0
 ## explicit
@@ -93,19 +95,19 @@ github.com/pmezard/go-difflib/difflib
 ## explicit
 github.com/ryanuber/go-glob
 # github.com/stretchr/objx v0.3.0
-## explicit; go 1.12
+## explicit
 github.com/stretchr/objx
 # github.com/stretchr/testify v1.7.0
-## explicit; go 1.13
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 # golang.org/x/text v0.3.7
-## explicit; go 1.17
+## explicit
 golang.org/x/text/transform
 golang.org/x/text/unicode/norm
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 ## explicit
 gopkg.in/yaml.v3
 # howett.net/plist v1.0.0
-## explicit; go 1.12
+## explicit
 howett.net/plist


### PR DESCRIPTION
This PR adds a new input argument to resolve issues around managing Xcode 13 new version and build number input when exporting. 

By default, Xcode has this set to `true` which causes unintentional effects and hard to track down bugs with version numbers. This update allows step users to configure this option by setting the value. To help avoid more issues it's been set to `false`, similar to the behaviour of the Xcode archive step.  